### PR TITLE
Clean IDPASS LITE initial integration from branch 1.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,6 +225,27 @@
             <version>${swagger.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.idpass</groupId>
+            <artifactId>idpass-lite-mosip</artifactId>
+            <version>1.0.4</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>3.12.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.zxing</groupId>
+            <artifactId>javase</artifactId>
+            <version>3.4.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.jai-imageio</groupId>
+            <artifactId>jai-imageio-jpeg2000</artifactId>
+            <version>1.3.0</version>
+        </dependency>
+
 		</dependencies>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.idpass</groupId>
+            <groupId>io.github.idpass</groupId>
             <artifactId>idpass-lite-java</artifactId>
             <version>1.0.0</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -227,8 +227,8 @@
 
         <dependency>
             <groupId>org.idpass</groupId>
-            <artifactId>idpass-lite-mosip</artifactId>
-            <version>1.0.4</version>
+            <artifactId>idpass-lite-java</artifactId>
+            <version>1.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>

--- a/src/main/java/io/mosip/print/PrintPDFApplication.java
+++ b/src/main/java/io/mosip/print/PrintPDFApplication.java
@@ -3,6 +3,7 @@ package io.mosip.print;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Primary;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
@@ -10,6 +11,7 @@ import io.mosip.kernel.cbeffutil.impl.CbeffImpl;
 import io.mosip.kernel.core.cbeffutil.spi.CbeffUtil;
 
 @SpringBootApplication
+@ComponentScan({"io.mosip.print", "org.idpass.lite"})
 public class PrintPDFApplication {
 
 	@Bean

--- a/src/main/java/io/mosip/print/service/impl/PrintServiceImpl.java
+++ b/src/main/java/io/mosip/print/service/impl/PrintServiceImpl.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+import org.idpass.lite.IDPassReaderComponent;
 import org.joda.time.DateTime;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
@@ -202,7 +203,9 @@ public class PrintServiceImpl implements PrintService{
 	
 	@Autowired
 	private PublisherClient<String, Object, HttpHeaders> pb;
-	
+
+    @Autowired
+    private IDPassReaderComponent qrCodeGenerator2;
 
 	/*
 	 * (non-Javadoc)
@@ -496,6 +499,8 @@ public class PrintServiceImpl implements PrintService{
 	 */
 	private boolean setQrCode(String qrString, Map<String, Object> attributes)
 			throws QrcodeGenerationException, IOException {
+        String pincode = "1234";
+        String photob64 = (String)attributes.get("ApplicantPhoto");
 		boolean isQRCodeSet = false;
 		JSONObject qrJsonObj = JsonUtil.objectMapperReadValue(qrString, JSONObject.class);
 		qrJsonObj.remove("individualBiometrics");
@@ -505,7 +510,7 @@ public class PrintServiceImpl implements PrintService{
 		// textFileJson.put("digitalSignature", digitalSignaturedQrData);
 		// Gson gson = new GsonBuilder().setPrettyPrinting().serializeNulls().create();
 		// String printTextFileString = gson.toJson(textFileJson);
-		byte[] qrCodeBytes = qrCodeGenerator.generateQrCode(qrJsonObj.toString(), QrVersion.V30);
+		byte[] qrCodeBytes = qrCodeGenerator2.generateQrCode(qrJsonObj.toString(), pincode, photob64);
 		if (qrCodeBytes != null) {
 			String imageString = CryptoUtil.encodeBase64String(qrCodeBytes);
 			attributes.put(QRCODE, "data:image/png;base64," + imageString);

--- a/src/main/java/io/mosip/print/service/impl/PrintServiceImpl.java
+++ b/src/main/java/io/mosip/print/service/impl/PrintServiceImpl.java
@@ -41,12 +41,10 @@ import io.mosip.kernel.core.exception.ExceptionUtils;
 import io.mosip.kernel.core.logger.spi.Logger;
 import io.mosip.kernel.core.pdfgenerator.exception.PDFGeneratorException;
 import io.mosip.kernel.core.qrcodegenerator.exception.QrcodeGenerationException;
-import io.mosip.kernel.core.qrcodegenerator.spi.QrCodeGenerator;
 import io.mosip.kernel.core.util.CryptoUtil;
 import io.mosip.kernel.core.util.DateUtils;
 import io.mosip.kernel.core.websub.spi.PublisherClient;
 import io.mosip.kernel.pdfgenerator.itext.constant.PDFGeneratorExceptionCodeConstant;
-import io.mosip.kernel.qrcode.generator.zxing.constant.QrVersion;
 import io.mosip.print.constant.ApiName;
 import io.mosip.print.constant.CardType;
 import io.mosip.print.constant.EventId;
@@ -170,10 +168,6 @@ public class PrintServiceImpl implements PrintService{
 	// RegistrationStatusService<String, InternalRegistrationStatusDto,
 	// RegistrationStatusDto> registrationStatusService;
 
-	/** The qr code generator. */
-	@Autowired
-	private QrCodeGenerator<QrVersion> qrCodeGenerator;
-
 	/** The Constant INDIVIDUAL_BIOMETRICS. */
 	private static final String INDIVIDUAL_BIOMETRICS = "individualBiometrics";
 
@@ -205,7 +199,7 @@ public class PrintServiceImpl implements PrintService{
 	private PublisherClient<String, Object, HttpHeaders> pb;
 
     @Autowired
-    private IDPassReaderComponent qrCodeGenerator2;
+    private IDPassReaderComponent idpassQrCodeGenerator;
 
 	/*
 	 * (non-Javadoc)
@@ -510,7 +504,7 @@ public class PrintServiceImpl implements PrintService{
 		// textFileJson.put("digitalSignature", digitalSignaturedQrData);
 		// Gson gson = new GsonBuilder().setPrettyPrinting().serializeNulls().create();
 		// String printTextFileString = gson.toJson(textFileJson);
-		byte[] qrCodeBytes = qrCodeGenerator2.generateQrCode(qrJsonObj.toString(), pincode, photob64);
+		byte[] qrCodeBytes = idpassQrCodeGenerator.generateQrCode(qrJsonObj.toString(), pincode, photob64);
 		if (qrCodeBytes != null) {
 			String imageString = CryptoUtil.encodeBase64String(qrCodeBytes);
 			attributes.put(QRCODE, "data:image/png;base64," + imageString);

--- a/src/main/java/org/idpass/lite/FieldDesc.java
+++ b/src/main/java/org/idpass/lite/FieldDesc.java
@@ -1,0 +1,79 @@
+package org.idpass.lite;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.util.List;
+
+public class FieldDesc {
+    private String value;
+    private boolean isMandatory;
+
+    // addressLine1,addressLine2,addressLine3,region,province,postalCode
+
+    public String from(JsonNode jnode)
+            throws IOException
+    {
+        String ret = null;
+
+        if (value.equals("id") || value.equals("UIN") || value.equals("dateOfBirth")) {
+            ret = jnode.get(value).asText();
+        } else {
+            StringBuilder sb = new StringBuilder();
+
+            for (String v : value.split(",")) {
+
+                if (jnode.has(v)) {
+                    String t = jnode.get(v).asText();
+                    ObjectMapper m = new ObjectMapper();
+                    List<SourceDesc> L = m.readValue(t, new TypeReference<List<SourceDesc>>(){});
+                    here:
+                    for (String x : IDPASSMap.lang) {
+                        for (SourceDesc s : L) {
+                            if (s.language.equals(x)) {
+                                sb.append(s.value + " ");
+                                break here;
+                            }
+                        }
+                    }
+                }
+            }
+
+            ret = sb.toString();
+        }
+
+        if (isMandatory) {
+            if (ret == null || ret.isBlank() || ret.isEmpty()) {
+                throw new IOException();
+            }
+        }
+
+        return ret;
+    }
+
+    public FieldDesc() {
+    }
+
+    public FieldDesc(String value, boolean isMandatory) {
+        this.value = value;
+        this.isMandatory = isMandatory;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public boolean isMandatory() {
+        return isMandatory;
+    }
+
+    public void setMandatory(boolean mandatory) {
+        isMandatory = mandatory;
+    }
+}

--- a/src/main/java/org/idpass/lite/FieldDesc.java
+++ b/src/main/java/org/idpass/lite/FieldDesc.java
@@ -13,6 +13,24 @@ public class FieldDesc {
 
     // addressLine1,addressLine2,addressLine3,region,province,postalCode
 
+    /**
+     * This method reads in a particular json node of the input json
+     * and uses this field's defined "value" and "isMandatory" definitions
+     * to do the extraction.
+     *
+     * Certain fields such as id, UIN and dateOfBirth are well defined and
+     * therefore they are read as-is. However, other fields may have comma-separated
+     * source field definitions and therefore needs to parsed and contents
+     * aggregated. For example, the "address" field.
+     *
+     * This method only extracts field values corresponding to the preferred language
+     * defined in IDPassMap.lang.
+     *
+     * @param jnode
+     * @return Returns the plain field value corresponding to preferred language
+     * @throws IOException Throws exception if a mandatory field is not found
+     */
+
     public String from(JsonNode jnode)
             throws IOException
     {
@@ -52,6 +70,8 @@ public class FieldDesc {
 
         return ret;
     }
+
+    /* Auto-generated getters/setters and constructors */
 
     public FieldDesc() {
     }

--- a/src/main/java/org/idpass/lite/IDPASSMap.java
+++ b/src/main/java/org/idpass/lite/IDPASSMap.java
@@ -80,7 +80,7 @@ public class IDPASSMap {
     }
 
     public FieldDesc getGivenName() {
-        currentField = "givenName";
+        currentField = givenName.getValue();
         return givenName;
     }
 
@@ -89,7 +89,7 @@ public class IDPASSMap {
     }
 
     public FieldDesc getSurName() {
-        currentField = "surName";
+        currentField = surName.getValue();
         return surName;
     }
 
@@ -106,7 +106,7 @@ public class IDPASSMap {
     }
 
     public FieldDesc getDateOfBirth() {
-        currentField = "dateOfBirth";
+        currentField = dateOfBirth.getValue();
         return dateOfBirth;
     }
 
@@ -140,31 +140,25 @@ public class IDPASSMap {
         String arr[];
 
         try {
-            switch (currentField) {
-                case "surName":
-                    arr = ret.split("\\s*(,|\\s)\\s*");
-                    if (ret.contains(",")) {
-                        ret = arr[0];
-                    } else {
-                        List<String> L = Arrays.asList(arr);
-                        ret = L.get(L.size() - 1);
-                    }
-                   break;
-
-                case "givenName":
-                    arr = ret.split("\\s*(,|\\s)\\s*");
-                    if (ret.contains(",")) {
-                        List<String> L = Arrays.asList(arr);
-                        ret = L.stream().skip(1).collect(Collectors.joining(" "));
-                    } else {
-                        ret = arr[0];
-                    }
-                    break;
-
-                case "dateOfBirth":
-                    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy/MM/d");
-                    LocalDate dob = LocalDate.parse(ret, formatter);
-                    break;
+            if (currentField.equals(surName.getValue())) {
+                arr = ret.split("\\s*(,|\\s)\\s*");
+                if (ret.contains(",")) {
+                    ret = arr[0];
+                } else {
+                    List<String> L = Arrays.asList(arr);
+                    ret = L.get(L.size() - 1);
+                }
+            } else if(currentField.equals(givenName.getValue())) {
+                arr = ret.split("\\s*(,|\\s)\\s*");
+                if (ret.contains(",")) {
+                    List<String> L = Arrays.asList(arr);
+                    ret = L.stream().skip(1).collect(Collectors.joining(" "));
+                } else {
+                    ret = arr[0];
+                }
+            } else if (currentField.equals(dateOfBirth.getValue())) {
+                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy/MM/d");
+                LocalDate dob = LocalDate.parse(ret, formatter);
             }
 
         } catch (ArrayIndexOutOfBoundsException | DateTimeParseException e) {

--- a/src/main/java/org/idpass/lite/IDPASSMap.java
+++ b/src/main/java/org/idpass/lite/IDPASSMap.java
@@ -16,7 +16,16 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/**
+ * The IDPASSMap class is the java rendetion of idpass-lite-map.json.
+ * It is used in the IdentFieldsDeserializer deserialization to map a
+ * source field(s) to a destination field.
+ */
+
 public class IDPASSMap {
+    /**
+     * These fields correspond to the idpass-lite-map.json
+     */
     public static List<String> lang;
     @JsonProperty("UIN")
     private FieldDesc UIN;
@@ -27,7 +36,10 @@ public class IDPASSMap {
     private FieldDesc dateOfBirth;
     private FieldDesc address;
 
-    private String f = "";
+    /* This is a temporary field used to hold the current field being parsed */
+    private String currentField = "";
+
+    /* Auto-generated getters/setters and constructors */
 
     public IDPASSMap() {
     }
@@ -68,7 +80,7 @@ public class IDPASSMap {
     }
 
     public FieldDesc getGivenName() {
-        f = "givenName";
+        currentField = "givenName";
         return givenName;
     }
 
@@ -77,7 +89,7 @@ public class IDPASSMap {
     }
 
     public FieldDesc getSurName() {
-        f = "surName";
+        currentField = "surName";
         return surName;
     }
 
@@ -94,7 +106,7 @@ public class IDPASSMap {
     }
 
     public FieldDesc getDateOfBirth() {
-        f = "dateOfBirth";
+        currentField = "dateOfBirth";
         return dateOfBirth;
     }
 
@@ -110,6 +122,16 @@ public class IDPASSMap {
         this.address = address;
     }
 
+    /**
+     * For most fields which are directly mapped such as "gender", the get() method is just
+     * a pass-through. But for fields with no direct mapping, such as the surName field, this method
+     * parses the input data argument which might contain "Doe, John"
+     * and extracts the "Doe" as the surName. The purpose of this method
+     * is to construct a surName from a fullName.
+     * @param data Source field value. For example, fullName = "Doe, John"
+     * @return Returns the best-effort attempt to extract the field value
+     */
+
     public String get(String data) {
         String ret = "";
         if (data == null) return ret;
@@ -118,7 +140,7 @@ public class IDPASSMap {
         String arr[];
 
         try {
-            switch (f) {
+            switch (currentField) {
                 case "surName":
                     arr = ret.split("\\s*(,|\\s)\\s*");
                     if (ret.contains(",")) {
@@ -149,9 +171,15 @@ public class IDPASSMap {
             System.out.println("parse error");
         }
 
-        f = "";
+        currentField = "";
         return ret;
     }
+
+    /**
+     * Loads the configuration json into the object to help in
+     * the deserialization of the input json.
+     * @return
+     */
 
     public static IDPASSMap getInstance() {
         InputStream is = IDPASSMap.class.getClassLoader().getResourceAsStream("idpass-lite-map.json");

--- a/src/main/java/org/idpass/lite/IDPASSMap.java
+++ b/src/main/java/org/idpass/lite/IDPASSMap.java
@@ -1,0 +1,173 @@
+package org.idpass.lite;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class IDPASSMap {
+    public static List<String> lang;
+    @JsonProperty("UIN")
+    private FieldDesc UIN;
+    private FieldDesc gender;
+    private FieldDesc givenName;
+    private FieldDesc surName;
+    private FieldDesc placeOfBirth;
+    private FieldDesc dateOfBirth;
+    private FieldDesc address;
+
+    private String f = "";
+
+    public IDPASSMap() {
+    }
+
+    public IDPASSMap(List<String> lang, FieldDesc UIN, FieldDesc gender, FieldDesc givenName, FieldDesc surName, FieldDesc placeOfBirth, FieldDesc dateOfBirth, FieldDesc address) {
+        this.lang = lang;
+        this.UIN = UIN;
+        this.gender = gender;
+        this.givenName = givenName;
+        this.surName = surName;
+        this.placeOfBirth = placeOfBirth;
+        this.dateOfBirth = dateOfBirth;
+        this.address = address;
+    }
+
+    public List<String> getLang() {
+        return lang;
+    }
+
+    public void setLang(List<String> lang) {
+        this.lang = lang;
+    }
+
+    public FieldDesc getUIN() {
+        return UIN;
+    }
+
+    public void setUIN(FieldDesc UIN) {
+        this.UIN = UIN;
+    }
+
+    public FieldDesc getGender() {
+        return gender;
+    }
+
+    public void setGender(FieldDesc gender) {
+        this.gender = gender;
+    }
+
+    public FieldDesc getGivenName() {
+        f = "givenName";
+        return givenName;
+    }
+
+    public void setGivenName(FieldDesc givenName) {
+        this.givenName = givenName;
+    }
+
+    public FieldDesc getSurName() {
+        f = "surName";
+        return surName;
+    }
+
+    public void setSurName(FieldDesc surName) {
+        this.surName = surName;
+    }
+
+    public FieldDesc getPlaceOfBirth() {
+        return placeOfBirth;
+    }
+
+    public void setPlaceOfBirth(FieldDesc placeOfBirth) {
+        this.placeOfBirth = placeOfBirth;
+    }
+
+    public FieldDesc getDateOfBirth() {
+        f = "dateOfBirth";
+        return dateOfBirth;
+    }
+
+    public void setDateOfBirth(FieldDesc dateOfBirth) {
+        this.dateOfBirth = dateOfBirth;
+    }
+
+    public FieldDesc getAddress() {
+        return address;
+    }
+
+    public void setAddress(FieldDesc address) {
+        this.address = address;
+    }
+
+    public String get(String data) {
+        String ret = "";
+        if (data == null) return ret;
+        else ret = data;
+
+        String arr[];
+
+        try {
+            switch (f) {
+                case "surName":
+                    arr = ret.split("\\s*(,|\\s)\\s*");
+                    if (ret.contains(",")) {
+                        ret = arr[0];
+                    } else {
+                        List<String> L = Arrays.asList(arr);
+                        ret = L.get(L.size() - 1);
+                    }
+                   break;
+
+                case "givenName":
+                    arr = ret.split("\\s*(,|\\s)\\s*");
+                    if (ret.contains(",")) {
+                        List<String> L = Arrays.asList(arr);
+                        ret = L.stream().skip(1).collect(Collectors.joining(" "));
+                    } else {
+                        ret = arr[0];
+                    }
+                    break;
+
+                case "dateOfBirth":
+                    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy/MM/d");
+                    LocalDate dob = LocalDate.parse(ret, formatter);
+                    break;
+            }
+
+        } catch (ArrayIndexOutOfBoundsException | DateTimeParseException e) {
+            System.out.println("parse error");
+        }
+
+        f = "";
+        return ret;
+    }
+
+    public static IDPASSMap getInstance() {
+        InputStream is = IDPASSMap.class.getClassLoader().getResourceAsStream("idpass-lite-map.json");
+        String json = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))
+                .lines()
+                .collect(Collectors.joining("\n"));
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+        IDPASSMap instance = null;
+        try {
+            instance = mapper.readValue(json, IDPASSMap.class);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return instance;
+    }
+}

--- a/src/main/java/org/idpass/lite/IDPassReaderComponent.java
+++ b/src/main/java/org/idpass/lite/IDPassReaderComponent.java
@@ -24,7 +24,6 @@ import com.github.jaiimageio.jpeg2000.impl.J2KImageReader;
  * an IDPassReader instance
  */
 
-//@Configuration
 @Component
 public class IDPassReaderComponent
 {

--- a/src/main/java/org/idpass/lite/IDPassReaderComponent.java
+++ b/src/main/java/org/idpass/lite/IDPassReaderComponent.java
@@ -4,7 +4,6 @@ import com.google.protobuf.ByteString;
 import io.mosip.kernel.core.util.CryptoUtil;
 import org.api.proto.Dat;
 import org.api.proto.Ident;
-import org.api.proto.KV;
 import org.idpass.lite.exceptions.IDPassException;
 import org.idpass.lite.proto.PostalAddress;
 import org.springframework.stereotype.Component;

--- a/src/main/java/org/idpass/lite/IDPassReaderComponent.java
+++ b/src/main/java/org/idpass/lite/IDPassReaderComponent.java
@@ -24,6 +24,7 @@ import com.github.jaiimageio.jpeg2000.impl.J2KImageReader;
  * an IDPassReader instance
  */
 
+//@Configuration
 @Component
 public class IDPassReaderComponent
 {
@@ -35,14 +36,11 @@ public class IDPassReaderComponent
      * @throws IDPassException Standard exception
      * @throws IOException Standard exception
      */
-    public IDPassReaderComponent()
+    public IDPassReaderComponent(IDPassliteConfig config)
             throws IDPassException, IOException
     {
         reader = new IDPassReader();
-        reader.setDetailsVisible(
-                IDPassReader.DETAIL_GIVENNAME |
-                IDPassReader.DETAIL_SURNAME |
-                IDPassReader.DETAIL_PLACEOFBIRTH);
+        reader.setDetailsVisible(config.getVisibleFields());
     }
 
     /**

--- a/src/main/java/org/idpass/lite/IDPassReaderComponent.java
+++ b/src/main/java/org/idpass/lite/IDPassReaderComponent.java
@@ -1,0 +1,113 @@
+package org.idpass.lite;
+
+import com.google.protobuf.ByteString;
+import io.mosip.kernel.core.util.CryptoUtil;
+import org.api.proto.Dat;
+import org.api.proto.Ident;
+import org.api.proto.KV;
+import org.idpass.lite.exceptions.IDPassException;
+import org.springframework.stereotype.Component;
+
+import javax.imageio.ImageIO;
+import javax.imageio.ImageReadParam;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import com.github.jaiimageio.jpeg2000.impl.J2KImageReader;
+
+@Component
+public class IDPassReaderComponent
+{
+    public IDPassReader reader;
+
+    public IDPassReaderComponent()
+            throws IDPassException, IOException
+    {
+        reader = new IDPassReader();
+        reader.setDetailsVisible(
+                IDPassReader.DETAIL_GIVENNAME |
+                IDPassReader.DETAIL_SURNAME |
+                IDPassReader.DETAIL_PLACEOFBIRTH);
+    }
+
+    public byte[] generateQrCode(String cs, String pincode, String photob64)
+    {
+        IdentFields idf = IdentFields.getInstance(cs);
+
+        Ident.Builder identBuilder = Ident.newBuilder()
+                .setPin(pincode);
+
+        String imageType = photob64.split(",")[0];
+        byte[] photo = CryptoUtil.decodeBase64(photob64.split(",")[1]);
+        photo = convertToJPG(photo);
+
+        if (photo != null) {
+            identBuilder.setPhoto(ByteString.copyFrom(photo));
+        }
+
+        /*
+        UIN
+        gender
+        givenName
+        surName
+        placeOfBirth
+        dateOfBirth
+        address
+        */
+
+        String dobStr = idf.getDateOfBirth();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy/MM/d");
+        LocalDate dob = LocalDate.parse(dobStr, formatter);
+        Dat dobProto = Dat.newBuilder()
+                .setYear(dob.getYear())
+                .setMonth(dob.getMonthValue())
+                .setDay(dob.getDayOfMonth())
+                .build();
+
+        identBuilder.addPrivExtra(KV.newBuilder().setKey("UIN").setValue(idf.getUIN()));
+        identBuilder.addPubExtra(KV.newBuilder().setKey("Gender").setValue(idf.getGender()));
+        identBuilder.addPubExtra(KV.newBuilder().setKey("Address").setValue(idf.getAddress()));
+        identBuilder.setGivenName(idf.getGivenName());
+        identBuilder.setSurName(idf.getSurName());
+        identBuilder.setPlaceOfBirth(idf.getPlaceOfBirth());
+        identBuilder.setDateOfBirth(dobProto);
+
+        Ident ident = identBuilder.build();
+        byte[] qrcodeId = null;
+
+        try {
+            Card card = reader.newCard(ident, null);
+            BufferedImage bi = card.asQRCode();
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            ImageIO.write(bi, "png", bos);
+            qrcodeId = bos.toByteArray();
+
+        } catch (IOException | IDPassException e) {
+            e.printStackTrace();
+        }
+
+        return  qrcodeId;
+    }
+
+    // Notes: copied from 'mosip-functional-tests' repo
+    private static byte[] convertToJPG(byte[] jp2Data) {
+        byte[] jpgImg = null;
+        J2KImageReader j2kImageReader = new J2KImageReader(null);
+        try {
+            j2kImageReader.setInput(ImageIO.createImageInputStream(new ByteArrayInputStream(jp2Data)));
+            ImageReadParam imageReadParam = j2kImageReader.getDefaultReadParam();
+            BufferedImage image = j2kImageReader.read(0, imageReadParam);
+            ByteArrayOutputStream imgBytes = new ByteArrayOutputStream();
+            ImageIO.write(image, "JPG", imgBytes);
+            jpgImg = imgBytes.toByteArray();
+        } catch (IOException e) {
+
+        }
+
+        return jpgImg;
+    }
+}

--- a/src/main/java/org/idpass/lite/IDPassReaderComponent.java
+++ b/src/main/java/org/idpass/lite/IDPassReaderComponent.java
@@ -19,11 +19,22 @@ import java.time.format.DateTimeFormatter;
 
 import com.github.jaiimageio.jpeg2000.impl.J2KImageReader;
 
+/**
+ * Spring boot singleton component execution wrapper of
+ * an IDPassReader instance
+ */
+
 @Component
 public class IDPassReaderComponent
 {
     public IDPassReader reader;
 
+    /**
+     * Instantiates IDPassReader reader with a particular configuration
+     *
+     * @throws IDPassException Standard exception
+     * @throws IOException Standard exception
+     */
     public IDPassReaderComponent()
             throws IDPassException, IOException
     {
@@ -34,8 +45,18 @@ public class IDPassReaderComponent
                 IDPassReader.DETAIL_PLACEOFBIRTH);
     }
 
+    /**
+     * Returns a PNG image QR code representation as a byte[] array,
+     * from the given inputs:
+     *
+     * @param cs The credential subject input json
+     * @param pincode The IDPASS LITE pin code
+     * @param photob64 A facial photo image
+     * @return Returns PNG QR code of the generated IDPASS LITE card
+     */
     public byte[] generateQrCode(String cs, String pincode, String photob64)
     {
+        // Parse credential subject input json to populate fields in IdentFields object
         IdentFields idf = IdentFields.getInstance(cs);
 
         Ident.Builder identBuilder = Ident.newBuilder()
@@ -43,7 +64,7 @@ public class IDPassReaderComponent
 
         String imageType = photob64.split(",")[0];
         byte[] photo = CryptoUtil.decodeBase64(photob64.split(",")[1]);
-        photo = convertToJPG(photo);
+        photo = convertJ2KToJPG(photo);
 
         if (photo != null) {
             identBuilder.setPhoto(ByteString.copyFrom(photo));
@@ -58,6 +79,8 @@ public class IDPassReaderComponent
         dateOfBirth
         address
         */
+
+        /* Populate Ident fields from idf object */
 
         String dobStr = idf.getDateOfBirth();
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy/MM/d");
@@ -94,7 +117,7 @@ public class IDPassReaderComponent
     }
 
     // Notes: copied from 'mosip-functional-tests' repo
-    private static byte[] convertToJPG(byte[] jp2Data) {
+    private static byte[] convertJ2KToJPG(byte[] jp2Data) {
         byte[] jpgImg = null;
         J2KImageReader j2kImageReader = new J2KImageReader(null);
         try {

--- a/src/main/java/org/idpass/lite/IDPassReaderComponent.java
+++ b/src/main/java/org/idpass/lite/IDPassReaderComponent.java
@@ -6,6 +6,7 @@ import org.api.proto.Dat;
 import org.api.proto.Ident;
 import org.api.proto.KV;
 import org.idpass.lite.exceptions.IDPassException;
+import org.idpass.lite.proto.PostalAddress;
 import org.springframework.stereotype.Component;
 
 import javax.imageio.ImageIO;
@@ -91,9 +92,16 @@ public class IDPassReaderComponent
                 .setDay(dob.getDayOfMonth())
                 .build();
 
-        identBuilder.addPrivExtra(KV.newBuilder().setKey("UIN").setValue(idf.getUIN()));
-        identBuilder.addPubExtra(KV.newBuilder().setKey("Gender").setValue(idf.getGender()));
-        identBuilder.addPubExtra(KV.newBuilder().setKey("Address").setValue(idf.getAddress()));
+        PostalAddress postalAddress = PostalAddress.newBuilder()
+                .setLanguageCode("en") /// TODO
+                .addAllAddressLines(idf.getAddressLines())
+                .build();
+
+        identBuilder.setUIN(idf.getUIN());
+        identBuilder.setFullName(idf.getFullName());
+        identBuilder.setPostalAddress(postalAddress);
+        identBuilder.setGender(idf.getGenderAsInt());
+
         identBuilder.setGivenName(idf.getGivenName());
         identBuilder.setSurName(idf.getSurName());
         identBuilder.setPlaceOfBirth(idf.getPlaceOfBirth());

--- a/src/main/java/org/idpass/lite/IDPassliteConfig.java
+++ b/src/main/java/org/idpass/lite/IDPassliteConfig.java
@@ -1,0 +1,90 @@
+package org.idpass.lite;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The DetailField enum provides a type safe configuration values
+ * in application.properties for the "idpass.lite.qrcode.detailsvisible" key.
+ *
+ * The configured comma-separated list of fields shall be visible by default
+ * in the generated QR code. The rest of the fields shall only be visible after a
+ * successful authentication.
+ */
+
+enum DetailField {
+    DETAIL_SURNAME(IDPassReader.DETAIL_SURNAME),
+    DETAIL_GIVENNAME(IDPassReader.DETAIL_GIVENNAME),
+    DETAIL_DATEOFBIRTH(IDPassReader.DETAIL_DATEOFBIRTH),
+    DETAIL_PLACEOFBIRTH(IDPassReader.DETAIL_PLACEOFBIRTH),
+    DETAIL_CREATEDAT(IDPassReader.DETAIL_CREATEDAT),
+    DETAIL_UIN(IDPassReader.DETAIL_UIN),
+    DETAIL_FULLNAME(IDPassReader.DETAIL_FULLNAME),
+    DETAIL_GENDER(IDPassReader.DETAIL_GENDER),
+    DETAIL_POSTALADDRESS(IDPassReader.DETAIL_POSTALADDRESS);
+
+    private int bitFlag;
+
+    public int getBitFlag() {
+        return bitFlag;
+    }
+
+    private DetailField(int value) {
+        bitFlag = value;
+    }
+}
+
+/**
+ * A standard spring boot class that reads configuration values in
+ * application.properties under a specified key prefix.
+ */
+
+@Configuration
+@ConfigurationProperties(prefix = "idpass.lite")
+public class IDPassliteConfig {
+
+    public static class QrCode {
+        // comma-separated list of fields configured in application.properties
+        private List<DetailField> detailsVisible = new ArrayList<>();
+
+        public List<DetailField> getDetailsVisible() {
+            return detailsVisible;
+        }
+
+        public void setDetailsVisible(List<DetailField> detailsVisible) {
+            this.detailsVisible = detailsVisible;
+        }
+    }
+
+    private QrCode qrcode = new QrCode();
+
+    /** Getter/Setter helper methods */
+
+    public QrCode getQrcode() {
+        return qrcode;
+    }
+
+    public void setQrcode(QrCode qrcode) {
+        this.qrcode = qrcode;
+    }
+
+    /**
+     * Convert the comma-separated list of fields into an integer bit flags
+     * @return The bit flags describing which field(s) are publicly visible when
+     * generating the QR code.
+     */
+
+    public int getVisibleFields() {
+        List<DetailField> visibleFields = qrcode.getDetailsVisible();
+        int bitFlags = 0;
+
+        for (DetailField f : visibleFields) {
+            bitFlags = bitFlags | f.getBitFlag();
+        }
+
+        return bitFlags;
+    }
+}

--- a/src/main/java/org/idpass/lite/IdentFields.java
+++ b/src/main/java/org/idpass/lite/IdentFields.java
@@ -1,12 +1,46 @@
 package org.idpass.lite;
 
-import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 
 import java.io.IOException;
 
+/**
+ * The IdentFields class represents the collection of fields
+ * which are inputs to the Ident protobuf message object.
+ *
+ * Through its associated IdentFieldsDeserializer class, and together with
+ * idpass-lite-map.json configuration, the IdentFields::getInstance(String cs)
+ * can accept an input json, and then extracts from this input json in order
+ * to populate the fields of IdentFields.
+ *
+ * The idpass-lite-map.json describes the source field(s) from where to extract
+ * data from the input json. In most cases, the source field name and the
+ * destination field name are the same. For example, to populate the
+ * IdentFields::gender field, the idpass-lite-map.json describes it as:
+ *
+ * "gender": {
+ *     "value": "gender",
+ *     "isMandatory": false
+ * }
+ *
+ * In general representation,
+ *
+ * "P": {
+ *     "value": "Q[,R,S,...]"
+ *     "isMandatory": false|true
+ * }
+ *
+ * where P corresponds to a field in IdentFields class, and the value can be
+ * a comma-separated list of source fields. For example, the IdentFields::address
+ * field is the aggregatation of several fields from the input json.
+ *
+ */
+
 public class IdentFields {
+    /**
+     * Only fields defined in IdentFields are valid input fields
+     */
     private String UIN;
     private String gender;
     private String givenName;
@@ -15,6 +49,12 @@ public class IdentFields {
     private String dateOfBirth;
     private String address;
 
+    /**
+     * Accepts a credential subject input json to construct a
+     * constrained IdentFields object.
+     * @param cs Credential subject json string
+     * @return Returns an IdentFields type
+     */
     public static IdentFields getInstance(String cs) {
         ObjectMapper mapper = new ObjectMapper();
         SimpleModule module = new SimpleModule();
@@ -31,6 +71,8 @@ public class IdentFields {
 
         return idf;
     }
+
+    /* Auto-generated getters/setters and constructors */
 
     public IdentFields() {
     }

--- a/src/main/java/org/idpass/lite/IdentFields.java
+++ b/src/main/java/org/idpass/lite/IdentFields.java
@@ -1,0 +1,103 @@
+package org.idpass.lite;
+
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import java.io.IOException;
+
+public class IdentFields {
+    private String UIN;
+    private String gender;
+    private String givenName;
+    private String surName;
+    private String placeOfBirth;
+    private String dateOfBirth;
+    private String address;
+
+    public static IdentFields getInstance(String cs) {
+        ObjectMapper mapper = new ObjectMapper();
+        SimpleModule module = new SimpleModule();
+        module.addDeserializer(IdentFields.class, new IdentFieldsDeserializer());
+        mapper.registerModule(module);
+
+        IdentFields idf = null;
+
+        try {
+            idf = mapper.readValue(cs, IdentFields.class);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return idf;
+    }
+
+    public IdentFields() {
+    }
+
+    public IdentFields(String UIN, String gender, String givenName, String surName, String placeOfBirth, String dateOfBirth, String address) {
+        this.UIN = UIN;
+        this.gender = gender;
+        this.givenName = givenName;
+        this.surName = surName;
+        this.placeOfBirth = placeOfBirth;
+        this.dateOfBirth = dateOfBirth;
+        this.address = address;
+    }
+
+    public String getUIN() {
+        return UIN;
+    }
+
+    public void setUIN(String UIN) {
+        this.UIN = UIN;
+    }
+
+    public String getGender() {
+        return gender;
+    }
+
+    public void setGender(String gender) {
+        this.gender = gender;
+    }
+
+    public String getGivenName() {
+        return givenName;
+    }
+
+    public void setGivenName(String givenName) {
+        this.givenName = givenName;
+    }
+
+    public String getSurName() {
+        return surName;
+    }
+
+    public void setSurName(String surName) {
+        this.surName = surName;
+    }
+
+    public String getPlaceOfBirth() {
+        return placeOfBirth;
+    }
+
+    public void setPlaceOfBirth(String placeOfBirth) {
+        this.placeOfBirth = placeOfBirth;
+    }
+
+    public String getDateOfBirth() {
+        return dateOfBirth;
+    }
+
+    public void setDateOfBirth(String dateOfBirth) {
+        this.dateOfBirth = dateOfBirth;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+}

--- a/src/main/java/org/idpass/lite/IdentFields.java
+++ b/src/main/java/org/idpass/lite/IdentFields.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * The IdentFields class represents the collection of fields
@@ -44,10 +45,11 @@ public class IdentFields {
     private String UIN;
     private String gender;
     private String givenName;
+    private String fullName;
     private String surName;
     private String placeOfBirth;
     private String dateOfBirth;
-    private String address;
+    private List<String> addressLines;
 
     /**
      * Accepts a credential subject input json to construct a
@@ -77,16 +79,6 @@ public class IdentFields {
     public IdentFields() {
     }
 
-    public IdentFields(String UIN, String gender, String givenName, String surName, String placeOfBirth, String dateOfBirth, String address) {
-        this.UIN = UIN;
-        this.gender = gender;
-        this.givenName = givenName;
-        this.surName = surName;
-        this.placeOfBirth = placeOfBirth;
-        this.dateOfBirth = dateOfBirth;
-        this.address = address;
-    }
-
     public String getUIN() {
         return UIN;
     }
@@ -101,6 +93,15 @@ public class IdentFields {
 
     public void setGender(String gender) {
         this.gender = gender;
+    }
+
+    public int getGenderAsInt() {
+        int g = 2;
+        switch (this.gender) { /// TODO
+            case "Male":
+                break;
+        }
+        return g;
     }
 
     public String getGivenName() {
@@ -135,11 +136,30 @@ public class IdentFields {
         this.dateOfBirth = dateOfBirth;
     }
 
-    public String getAddress() {
-        return address;
+    public String getFullName() {
+        return fullName;
     }
 
-    public void setAddress(String address) {
-        this.address = address;
+    public void setFullName(String fullName) {
+        this.fullName = fullName;
+    }
+
+    public List<String> getAddressLines() {
+        return addressLines;
+    }
+
+    public void setAddressLines(List<String> addressLines) {
+        this.addressLines = addressLines;
+    }
+
+    public IdentFields(String UIN, String gender, String givenName, String fullName, String surName, String placeOfBirth, String dateOfBirth, List<String> addressLines) {
+        this.UIN = UIN;
+        this.gender = gender;
+        this.givenName = givenName;
+        this.fullName = fullName;
+        this.surName = surName;
+        this.placeOfBirth = placeOfBirth;
+        this.dateOfBirth = dateOfBirth;
+        this.addressLines = addressLines;
     }
 }

--- a/src/main/java/org/idpass/lite/IdentFieldsDeserializer.java
+++ b/src/main/java/org/idpass/lite/IdentFieldsDeserializer.java
@@ -1,0 +1,61 @@
+package org.idpass.lite;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import java.io.IOException;
+
+public class IdentFieldsDeserializer extends StdDeserializer<IdentFields> {
+
+    public IdentFieldsDeserializer() {
+        this(null);
+    }
+
+    public IdentFieldsDeserializer(Class<?> vc) {
+        super(vc);
+    }
+
+    @Override
+    public IdentFields deserialize(JsonParser parser, DeserializationContext deserializationContext)
+            throws IOException, JsonProcessingException
+    {
+        IDPASSMap idpassMap = IDPASSMap.getInstance();
+
+        IdentFields ret = new IdentFields();
+        ObjectCodec codec = parser.getCodec();
+        JsonNode node = codec.readTree(parser);
+
+        /*
+        UIN
+        gender
+        givenName
+        surName
+        placeOfBirth
+        dateOfBirth
+        address
+        */
+
+        String address = idpassMap.get(idpassMap.getAddress().from(node));
+        String UIN = idpassMap.get(idpassMap.getUIN().from(node));
+        String gender = idpassMap.get(idpassMap.getGender().from(node));
+
+        String surName = idpassMap.get(idpassMap.getSurName().from(node));
+        String givenName = idpassMap.get(idpassMap.getGivenName().from(node));
+
+        String placeOfBirth = idpassMap.get(idpassMap.getPlaceOfBirth().from(node));
+        String dateOfBirth = idpassMap.get(idpassMap.getDateOfBirth().from(node));
+
+        ret.setGivenName(givenName);
+        ret.setSurName(surName);
+        ret.setUIN(UIN);
+        ret.setGender(gender);
+        ret.setPlaceOfBirth(placeOfBirth);
+        ret.setDateOfBirth(dateOfBirth);
+        ret.setAddress(address);
+
+        return ret;
+    }
+}

--- a/src/main/java/org/idpass/lite/IdentFieldsDeserializer.java
+++ b/src/main/java/org/idpass/lite/IdentFieldsDeserializer.java
@@ -8,6 +8,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import java.io.IOException;
 
+/**
+ * The associated deserializer of IdentFields
+ */
+
 public class IdentFieldsDeserializer extends StdDeserializer<IdentFields> {
 
     public IdentFieldsDeserializer() {
@@ -18,13 +22,28 @@ public class IdentFieldsDeserializer extends StdDeserializer<IdentFields> {
         super(vc);
     }
 
+    /**
+     * Deserialization implementation. Loads credential subject input json into a tree,
+     * and extracts the field values map defined in idpass-map-lite.json.
+     *
+     * @param parser Standard parser
+     * @param deserializationContext Standard context
+     * @return Returns an IdentFields type with populated fields
+     * @throws IOException Standard exception
+     * @throws JsonProcessingException Standard exception
+     */
+
     @Override
     public IdentFields deserialize(JsonParser parser, DeserializationContext deserializationContext)
             throws IOException, JsonProcessingException
     {
+        // Loads idpass-map-lite.json into idpassMap object
         IDPASSMap idpassMap = IDPASSMap.getInstance();
 
+        // Prepare returned value
         IdentFields ret = new IdentFields();
+
+        // Loads credential subject input json
         ObjectCodec codec = parser.getCodec();
         JsonNode node = codec.readTree(parser);
 
@@ -38,6 +57,8 @@ public class IdentFieldsDeserializer extends StdDeserializer<IdentFields> {
         address
         */
 
+        /* Extract the mapped fields */
+
         String address = idpassMap.get(idpassMap.getAddress().from(node));
         String UIN = idpassMap.get(idpassMap.getUIN().from(node));
         String gender = idpassMap.get(idpassMap.getGender().from(node));
@@ -48,6 +69,7 @@ public class IdentFieldsDeserializer extends StdDeserializer<IdentFields> {
         String placeOfBirth = idpassMap.get(idpassMap.getPlaceOfBirth().from(node));
         String dateOfBirth = idpassMap.get(idpassMap.getDateOfBirth().from(node));
 
+        /* Populate fields into return value */
         ret.setGivenName(givenName);
         ret.setSurName(surName);
         ret.setUIN(UIN);

--- a/src/main/java/org/idpass/lite/IdentFieldsDeserializer.java
+++ b/src/main/java/org/idpass/lite/IdentFieldsDeserializer.java
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * The associated deserializer of IdentFields
@@ -59,7 +61,7 @@ public class IdentFieldsDeserializer extends StdDeserializer<IdentFields> {
 
         /* Extract the mapped fields */
 
-        String address = idpassMap.get(idpassMap.getAddress().from(node));
+        String address = idpassMap.get(idpassMap.getAddress().from(node)); /// TODO
         String UIN = idpassMap.get(idpassMap.getUIN().from(node));
         String gender = idpassMap.get(idpassMap.getGender().from(node));
 
@@ -69,6 +71,9 @@ public class IdentFieldsDeserializer extends StdDeserializer<IdentFields> {
         String placeOfBirth = idpassMap.get(idpassMap.getPlaceOfBirth().from(node));
         String dateOfBirth = idpassMap.get(idpassMap.getDateOfBirth().from(node));
 
+        List<String> addressLines = new ArrayList<>();
+        addressLines.add(address);
+
         /* Populate fields into return value */
         ret.setGivenName(givenName);
         ret.setSurName(surName);
@@ -76,7 +81,8 @@ public class IdentFieldsDeserializer extends StdDeserializer<IdentFields> {
         ret.setGender(gender);
         ret.setPlaceOfBirth(placeOfBirth);
         ret.setDateOfBirth(dateOfBirth);
-        ///ret.setAddress(address); /// TODO
+        ret.setAddressLines(addressLines);
+        ret.setFullName(givenName + " " + surName);
 
         return ret;
     }

--- a/src/main/java/org/idpass/lite/IdentFieldsDeserializer.java
+++ b/src/main/java/org/idpass/lite/IdentFieldsDeserializer.java
@@ -76,7 +76,7 @@ public class IdentFieldsDeserializer extends StdDeserializer<IdentFields> {
         ret.setGender(gender);
         ret.setPlaceOfBirth(placeOfBirth);
         ret.setDateOfBirth(dateOfBirth);
-        ret.setAddress(address);
+        ///ret.setAddress(address); /// TODO
 
         return ret;
     }

--- a/src/main/java/org/idpass/lite/SourceDesc.java
+++ b/src/main/java/org/idpass/lite/SourceDesc.java
@@ -1,0 +1,6 @@
+package org.idpass.lite;
+
+public class SourceDesc {
+    public String language;
+    public String value;
+}

--- a/src/main/java/org/idpass/lite/SourceDesc.java
+++ b/src/main/java/org/idpass/lite/SourceDesc.java
@@ -1,5 +1,10 @@
 package org.idpass.lite;
 
+/**
+ * A DTO helper map to handle an array of
+ * language/value objects
+ */
+
 public class SourceDesc {
     public String language;
     public String value;

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,3 +1,5 @@
+idpass.lite.qrcode.detailsvisible=DETAIL_SURNAME, DETAIL_GIVENNAME, DETAIL_PLACEOFBIRTH
+
 mosip.event.hubURL=http://localhost:9191/websub
 mosip.partner.id=792112
 mosip.event.topic=${mosip.partner.id}/CREDENTIAL_ISSUED

--- a/src/main/resources/idpass-lite-map.json
+++ b/src/main/resources/idpass-lite-map.json
@@ -1,0 +1,39 @@
+{
+        "lang": ["eng", "fra"],
+		"UIN": {
+			"value": "UIN",
+			"isMandatory" : true
+		},
+		"gender": {
+			"value": "gender",
+			"isMandatory" : false
+		},
+		"photo": {
+			"value": "photo",
+			"isMandatory" : false
+		},
+		"givenName": {
+			"value": "fullName",
+			"isMandatory" : true
+		},
+		"surName": {
+			"value": "fullName",
+			"isMandatory" : true
+		},
+		"placeOfBirth": {
+			"value": "placeOfBirth",
+			"isMandatory" : true
+		},
+		"dateOfBirth": {
+			"value": "dateOfBirth",
+			"isMandatory" : true
+		},
+		"pin": {
+			"value": "pin",
+			"isMandatory" : true
+		},
+		"address": {
+			"value": "addressLine1,addressLine2,addressLine3,region,province,postalCode",
+			"isMandatory" : false 
+		}
+}


### PR DESCRIPTION
Replace MOSIP's `qrCodeGenerator` with IDPASS LITE's `qrCodeGenerator2`.

Newly added IDPASS LITE's files are in a different package `org.idpass.lite` folder. The IDPASS json mapper loads `idpass-lite-map.json`. My idea of this mapper is for it to:

- Monitor the count of characters that will enter into the POJO object
- Define the source json fields, and if they are mandatory, from where to get (or aggregate content) into the POJO object field.

An example use case are the following:

- A MOSIP field content is represented in various languages as an array that looks like: `[{"language": "en", "value": "Male"}, {"language": "ru", "value": "мужчина"}]`. The `idpass-lite-map.json` has a `["en", "fra"]` list to denote preferred language in that order.
- MOSIP fields has `fullName` that combines the complete name. Whereas, IDPASS LITE has separate components: `surName` and `givenName`. I'm only aware that if a comma separates them, then the first one is the `surName` and the rest becomes the `givenName`. This part is difficult to correctly decode.

In summary, after replacing `qrCodeGenerator` with `qrCodeGenerator2` as shown in the diff, the 2 resulting generated PDF files can be found [here](https://drive.google.com/drive/folders/1WWTPG3a7vODYtXcw1du_o0_UCyoqkuEV) It is using the `Event_Unencrypted.json` file which I sent via POSTMAN.